### PR TITLE
[WIP] php7 return types

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -339,6 +339,7 @@ pub struct FunctionDecl {
     /// the boolean indicates whether to bind by-reference (true)
     pub usev: Vec<(bool, RcStr)>,
     pub ret_ref: bool,
+    pub ret_type: Option<RcStr>
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -733,6 +733,8 @@ impl Parser {
                 }
             }))
         };
+
+
         if_lookahead_expect!(self, Token::ParenthesesOpen, Token::ParenthesesOpen);
         let (params, params_err) = self.parse_parameter_list();
         if_lookahead!(self, Token::ParenthesesClose, _tok, {}, return Err(params_err.unwrap()));
@@ -753,7 +755,16 @@ impl Parser {
                 if_lookahead_expect!(self, Token::ParenthesesClose, Token::ParenthesesClose);
             });
         }
-        // TODO: return_type
+
+        let return_type = if_lookahead!(self, Token::Colon, _tok, {
+            if_lookahead!(self, Token::String(_), _tok, {
+                match _tok.0 {
+                    Token::String(str_) => Some(str_),
+                    _ => None,
+                }
+            }, None)
+        }, None);
+
         let no_body = if allow_abstract {
             if_lookahead!(self, Token::SemiColon, _tok, true, false)
         } else {
@@ -776,6 +787,7 @@ impl Parser {
             body: body,
             usev: use_variables,
             ret_ref: returns_ref,
+            ret_type: return_type
         };
         let span = mk_span(span.start, self.tokens[self.pos - 1].1.end);
         Ok(Stmt(match name {

--- a/src/tests/expr.rs
+++ b/src/tests/expr.rs
@@ -294,7 +294,7 @@ fn parse_expr_assoc_array() {
 fn parse_expr_closure() {
     assert_eq!(process_expr("function () { c(); }"), enb!(0,20, Expr_::Function(FunctionDecl {
         params: vec![],
-        body: Some(Block(vec![ senb!(14,17, Expr_::Call(eb!(14,15, Expr_::Path(Path::identifier(false, "c".into()))), vec![])) ])), usev: vec![], ret_ref: false,
+        body: Some(Block(vec![ senb!(14,17, Expr_::Call(eb!(14,15, Expr_::Path(Path::identifier(false, "c".into()))), vec![])) ])), usev: vec![], ret_ref: false, ret_type : None
     })));
 }
 

--- a/src/tests/stmt.rs
+++ b/src/tests/stmt.rs
@@ -259,25 +259,33 @@ fn parse_stmt_switch() {
 #[test]
 fn parse_stmt_func_decl() {
     assert_eq!(process_stmt("function test() { ok(); }"), st!(0,25, Stmt_::Decl(Decl::GlobalFunction("test".into(), FunctionDecl { params: vec![],
-        body: Some(Block(vec![ senb!(18,22, Expr_::Call(eb!(18,20, Expr_::Path(Path::identifier(false, "ok".into()))), vec![])) ])), usev: vec![], ret_ref: false, })
+        body: Some(Block(vec![ senb!(18,22, Expr_::Call(eb!(18,20, Expr_::Path(Path::identifier(false, "ok".into()))), vec![])) ])), usev: vec![], ret_ref: false, ret_type : None })
     )));
     assert_eq!(process_stmt("function &test() { ok(); }"), st!(0,26, Stmt_::Decl(Decl::GlobalFunction("test".into(), FunctionDecl { params: vec![],
-        body: Some(Block(vec![ senb!(19,23, Expr_::Call(eb!(19,21, Expr_::Path(Path::identifier(false, "ok".into()))), vec![])) ])), usev: vec![], ret_ref: true, })
+        body: Some(Block(vec![ senb!(19,23, Expr_::Call(eb!(19,21, Expr_::Path(Path::identifier(false, "ok".into()))), vec![])) ])), usev: vec![], ret_ref: true, ret_type : None })
     )));
     assert_eq!(process_stmt("function test($a) { ok(); }"), st!(0,27, Stmt_::Decl(Decl::GlobalFunction("test".into(), FunctionDecl {
         params: vec![ParamDefinition { name: "a".into(), as_ref: false, variadic: false, ty: None, default: None }],
-        body: Some(Block(vec![ senb!(20,24, Expr_::Call(eb!(20,22, Expr_::Path(Path::identifier(false, "ok".into()))), vec![])) ])), usev: vec![], ret_ref: false, })
+        body: Some(Block(vec![ senb!(20,24, Expr_::Call(eb!(20,22, Expr_::Path(Path::identifier(false, "ok".into()))), vec![])) ])), usev: vec![], ret_ref: false, ret_type : None })
     )));
     assert_eq!(process_stmt("function test($a, $b) { ok(); }"), st!(0,31, Stmt_::Decl(Decl::GlobalFunction("test".into(), FunctionDecl {
         params: vec![
             ParamDefinition { name: "a".into(), as_ref: false, variadic: false, ty: None, default: None },
             ParamDefinition { name: "b".into(), as_ref: false, variadic: false, ty: None, default: None }
         ],
-        body: Some(Block(vec![ senb!(24,28, Expr_::Call(eb!(24,26, Expr_::Path(Path::identifier(false, "ok".into()))), vec![])) ])), usev: vec![], ret_ref: false, })
+        body: Some(Block(vec![ senb!(24,28, Expr_::Call(eb!(24,26, Expr_::Path(Path::identifier(false, "ok".into()))), vec![])) ])), usev: vec![], ret_ref: false, ret_type : None })
     )));
     assert_eq!(process_stmt("function test(...$a) { ok(); }"), st!(0,30, Stmt_::Decl(Decl::GlobalFunction("test".into(), FunctionDecl {
         params: vec![ParamDefinition { name: "a".into(), as_ref: false, variadic: true, ty: None, default: None }],
-        body: Some(Block(vec![ senb!(23,27, Expr_::Call(eb!(23,25, Expr_::Path(Path::identifier(false, "ok".into()))), vec![])) ])), usev: vec![], ret_ref: false, })
+        body: Some(Block(vec![ senb!(23,27, Expr_::Call(eb!(23,25, Expr_::Path(Path::identifier(false, "ok".into()))), vec![])) ])), usev: vec![], ret_ref: false, ret_type : None })
+    )));
+}
+
+#[test]
+fn parse_func_return_typehint() {
+    assert_eq!(process_stmt("function test(Test $a) : bool { ok(); }"), st!(0,39, Stmt_::Decl(Decl::GlobalFunction("test".into(), FunctionDecl {
+        params: vec![ ParamDefinition { name: "a".into(), as_ref: false, variadic: false, ty: Some(Ty::Object(Some(Path::identifier(false, "Test".into())))), default: None } ],
+        body: Some(Block(vec![ senb!(32,36, Expr_::Call(eb!(32,34, Expr_::Path(Path::identifier(false, "ok".into()))), vec![])) ])), usev: vec![], ret_ref: false, ret_type : Some("bool".into()) })
     )));
 }
 
@@ -285,7 +293,7 @@ fn parse_stmt_func_decl() {
 fn parse_func_decl_typehint() {
     assert_eq!(process_stmt("function test(Test $a) { ok(); }"), st!(0,32, Stmt_::Decl(Decl::GlobalFunction("test".into(), FunctionDecl {
         params: vec![ ParamDefinition { name: "a".into(), as_ref: false, variadic: false, ty: Some(Ty::Object(Some(Path::identifier(false, "Test".into())))), default: None } ],
-        body: Some(Block(vec![ senb!(25,29, Expr_::Call(eb!(25,27, Expr_::Path(Path::identifier(false, "ok".into()))), vec![])) ])), usev: vec![], ret_ref: false, })
+        body: Some(Block(vec![ senb!(25,29, Expr_::Call(eb!(25,27, Expr_::Path(Path::identifier(false, "ok".into()))), vec![])) ])), usev: vec![], ret_ref: false, ret_type : None })
     )));
 }
 
@@ -331,7 +339,7 @@ fn parse_class_methods() {
         cmod: ClassModifiers::none(), name: "Test".into(), base_class: None, implements: vec![],
         members: vec![ Member::Method(MemberModifiers::new(&[MemberModifier::Public]), "a".into(), FunctionDecl {
             params: vec![], body: Some(Block(vec![ senb!(35,40, Expr_::Call(eb!(35,38, Expr_::Path(Path::identifier(false, "run".into()))), vec![])) ])),
-            usev: vec![], ret_ref: false,
+            usev: vec![], ret_ref: false, ret_type : None,
         })]
     }))));
     assert_eq!(process_stmt("class Test { public function __construct(array $param1 = []) { $this->param = $param1; } }"),
@@ -341,7 +349,7 @@ fn parse_class_methods() {
                 params: vec![ParamDefinition { name: "param1".into(), as_ref: false, variadic: false, ty: Some(Ty::Array), default: Some(enb!(57,59, Expr_::Array(vec![]))) }],
                 body: Some(Block(vec![ senb!(63,85, Expr_::Assign(eb!(63,75, Expr_::ObjMember(eb!(63,68, Expr_::Variable("this".into())), vec![
                     enb!(70,75, Expr_::Path(Path::identifier(false, "param".into()))) ])), eb!(78,85, Expr_::Variable("param1".into()))))
-                ])), usev: vec![], ret_ref: false,
+                ])), usev: vec![], ret_ref: false, ret_type : None,
             })]
         })))
     );
@@ -375,7 +383,7 @@ fn parse_interface_decl() {
     assert_eq!(process_stmt("interface ITest {}"), st!(0,18, Stmt_::Decl(Decl::Interface("ITest".into(), vec![], vec![]))));
     assert_eq!(process_stmt("interface ITest { public function test(); }"), st!(0,43, Stmt_::Decl(
         Decl::Interface("ITest".into(), vec![], vec![ Member::Method(MemberModifiers::new(&[MemberModifier::Public]),
-            "test".into(), FunctionDecl {params: vec![], body: None, usev: vec![], ret_ref: false})
+            "test".into(), FunctionDecl {params: vec![], body: None, usev: vec![], ret_ref: false, ret_type : None})
         ])
     )));
 }
@@ -414,7 +422,7 @@ fn parse_global_decl() {
 #[test]
 fn parse_stmt_closure_use() {
     assert_eq!(process_stmt("return function () use ($t) {};"), st!(0,31, Stmt_::Return(Some(eb!(7,30, Expr_::Function(FunctionDecl {
-        params: vec![], body: Some(Block(vec![])), usev: vec![(false, "t".into())], ret_ref: false,
+        params: vec![], body: Some(Block(vec![])), usev: vec![(false, "t".into())], ret_ref: false, ret_type : None,
     }))))));
 }
 


### PR DESCRIPTION
this PR is work in progress.
it seems to work great for scalar values like: `function test() : bool { ok(); }` but returning classes fails: `function test() : \foo\bar { ok(); }`
